### PR TITLE
[WIP] extended tests: append buildlogs

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -606,7 +606,15 @@ func StartBuildAndWait(oc *CLI, args ...string) (result *BuildResult, err error)
 	if err != nil {
 		return result, err
 	}
-	return result, WaitForBuildResult(oc.BuildClient().Build().Builds(oc.Namespace()), result)
+	err = WaitForBuildResult(oc.BuildClient().Build().Builds(oc.Namespace()), result)
+	if err != nil {
+		return result, err
+	}
+	log, err := result.Logs()
+	fmt.Println("framework.StartBuildAndWait() - Printing build logs")
+	fmt.Println(log)
+	fmt.Println("framework.StartBuildAndWait() - Printed build logs")
+	return result, err
 }
 
 // WaitForBuildResult updates result wit the state of the build


### PR DESCRIPTION
PR for testing purposes only

Enable timestamps from docker builds logs for https://github.com/openshift/origin/issues/19077#issuecomment-379750489